### PR TITLE
Update daemon PID before parent exits

### DIFF
--- a/daemonize.py
+++ b/daemonize.py
@@ -106,6 +106,8 @@ class Daemonize(object):
                 self.logger.error("Unable to fork, errno: {0}".format(e.errno))
                 sys.exit(1)
             if process_id != 0:
+                with open(self.pid, "w") as pidfile:
+                    pidfile.write(str(process_id))
                 if self.keep_fds:
                     # This is the parent process. Exit without cleanup,
                     # see https://github.com/thesharp/daemonize/issues/46


### PR DESCRIPTION
I have an issue that I wish to `wait` on the daemon PID so ask for the contents of the pid file immediately after the call to start the daemon.  The problem is that there is a delay between the parent process exiting and the daemon writing it's actual PID to the pidfile. During this window the PID file exists but is empty so I can't `wait` on the PID unless I have a `sleep` immediately after starting the daemon. This seemed like an clumsy solution so the proposed change would see the parent (which knows the daemon PID) write it out immediately before exiting.

I hope you agree this is a sensible change. If not, perhaps you can think of a different solution.  